### PR TITLE
chore: Update checkout and node versions to v4

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -9,7 +9,7 @@ jobs:
         python: ['3.7', '3.8']
         os: ['ubuntu-latest']
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v1
         with:


### PR DESCRIPTION
Update checkout and node versions to v4: https://hostingers.atlassian.net/browse/AUTO-3944